### PR TITLE
BUGFIX: update weaken results to correctly reflect change when close to minSecurity

### DIFF
--- a/src/NetscriptFunctions.ts
+++ b/src/NetscriptFunctions.ts
@@ -394,7 +394,10 @@ export const ns: InternalAPI<NSFull> = {
         throw helpers.errorMessage(ctx, `Cannot find host of WorkerScript. Hostname: ${ctx.workerScript.hostname}.`);
       }
       const weakenAmt = getWeakenEffect(threads, host.cpuCores);
+      const securityBeforeWeaken = server.hackDifficulty;
       server.weaken(weakenAmt);
+      const securityAfterWeaken = server.hackDifficulty;
+      const securityReduction = securityBeforeWeaken - securityAfterWeaken;
       ctx.workerScript.scriptRef.recordWeaken(server.hostname, threads);
       const expGain = calculateHackingExpGain(server, Player) * threads;
       helpers.log(
@@ -407,7 +410,7 @@ export const ns: InternalAPI<NSFull> = {
       ctx.workerScript.scriptRef.onlineExpGained += expGain;
       Player.gainHackingExp(expGain);
       // Account for hidden multiplier in Server.weaken()
-      return Promise.resolve(weakenAmt);
+      return Promise.resolve(securityReduction);
     });
   },
   weakenAnalyze:


### PR DESCRIPTION
# Bug fix
- Include how it was tested

Should return 0 if already at minSecurity.

```js
/** @param {NS} ns */
export async function main(ns) {
  const target = ns.args[0] ?? "n00dles";
  ns.tail();
  ns.nuke(target)
  const sec = await ns.weaken(target);
  ns.tprint(sec);
}
```